### PR TITLE
Fix - Graceful Multicall Errors

### DIFF
--- a/src/multicall/MulticallBatch.ts
+++ b/src/multicall/MulticallBatch.ts
@@ -59,7 +59,14 @@ export class MulticallBatch {
   async execute() {
     const data = encodeCalls(this.calls)
     debug('execute', { batchId: this.id })
-    const returnData = await this.executor.execute(data)
+    
+    let returnData = null
+
+    try {
+      returnData = await this.executor.execute(data)
+    } catch (e) {
+      console.warn(`executor.execute() failed`, e)
+    }
 
     if (returnData) {
       const [blockNumber, returnValues] = decodeCalls(returnData)
@@ -67,8 +74,6 @@ export class MulticallBatch {
       for (let i = 0; i < returnValues.length; i++) {
         this.calls[i].resolve(returnValues[i])
       }
-    } else {
-      debug('returnData was returned null, possibly interrupted by refresh or page change')
     }
   }
 }

--- a/src/multicall/MulticallBatch.ts
+++ b/src/multicall/MulticallBatch.ts
@@ -60,10 +60,15 @@ export class MulticallBatch {
     const data = encodeCalls(this.calls)
     debug('execute', { batchId: this.id })
     const returnData = await this.executor.execute(data)
-    const [blockNumber, returnValues] = decodeCalls(returnData)
 
-    for (let i = 0; i < returnValues.length; i++) {
-      this.calls[i].resolve(returnValues[i])
+    if (returnData) {
+      const [blockNumber, returnValues] = decodeCalls(returnData)
+
+      for (let i = 0; i < returnValues.length; i++) {
+        this.calls[i].resolve(returnValues[i])
+      }
+    } else {
+      debug('returnData was returned null, possibly interrupted by refresh or page change')
     }
   }
 }

--- a/src/multicall/MulticallExecutor.ts
+++ b/src/multicall/MulticallExecutor.ts
@@ -23,9 +23,12 @@ export class MulticallExecutor {
     }
     const provider = await this.providerSource()
 
-    const result = await provider.call(tx)
-
-    return result
+    try {
+      const result = await provider.call(tx)
+      return result
+    } catch (e) {
+      return null
+    }
   }
 
   async multicallAddressOrThrow() {

--- a/src/multicall/MulticallExecutor.ts
+++ b/src/multicall/MulticallExecutor.ts
@@ -23,12 +23,9 @@ export class MulticallExecutor {
     }
     const provider = await this.providerSource()
 
-    try {
-      const result = await provider.call(tx)
-      return result
-    } catch (e) {
-      return null
-    }
+    const result = await provider.call(tx)
+
+    return result
   }
 
   async multicallAddressOrThrow() {

--- a/src/resolvers/queries/callResolver.ts
+++ b/src/resolvers/queries/callResolver.ts
@@ -55,7 +55,7 @@ export async function callResolver(contractCache: ContractCache, providerSource:
       return returns
     } catch (error) {
       const msg = `${identifier} ${fn}(${JSON.stringify(params)}): ${error.message || error}`
-      console.error(msg, error)
+      console.warn(msg, error)
       throw msg
     }
   }


### PR DESCRIPTION
This fixes our error reporting to ignore null values returned from ethers, which happens when a request is interrupted by refreshing, page change, close window/tab, or Ethereum network change